### PR TITLE
Stateful Session w/ Basic HTTP Auth

### DIFF
--- a/quackpipe.go
+++ b/quackpipe.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"bufio"
 	"database/sql"
 	_ "embed"
@@ -63,15 +64,17 @@ func quack(query string, stdin bool, format string, params string, hashdb string
 
 
 	if !stdin {
-		check(db.Exec("LOAD httpfs; LOAD json; LOAD parquet;"))
+		check(db.ExecContext(context.Background(),"LOAD httpfs; LOAD json; LOAD parquet;"))
+		check(db.ExecContext(context.Background(),"SET autoinstall_known_extensions=1;"))
+		check(db.ExecContext(context.Background(),"SET autoload_known_extensions=1;"))
 	}
 
 	if (alias) && (staticAliases != "") {
-		check(db.Exec(staticAliases))
+		check(db.ExecContext(context.Background(), staticAliases))
 	}
 
 	startTime := time.Now()
-	rows, err := db.Query(query)
+	rows, err := db.QueryContext(context.Background(), query)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR experiments with adding stateful sessions (with named DBs) based on HTTP Basic Authentication.

- [x] Hash Basic Auth to DB file
  - [x] Extend DuckDB parameters w/ DB file
- [x] Use Context
- [x] Optional Aliases